### PR TITLE
Fix potential SAX parser error

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
@@ -156,10 +156,6 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 
             reader.close();
             writer.close();
-
-            File temp3 = File.createTempFile("jhh", ".tmp");//XXX
-            Files.copy(tempFile, temp3);
-
             tempFile.delete();
 
             if (!temp2.renameTo(tempFile)) {

--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
@@ -6,11 +6,15 @@ import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
 import hudson.scm.SCM;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,10 +27,13 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import com.google.common.io.Files;
+
 public class MultiSCMChangeLogParser extends ChangeLogParser {
 
 	public static final String ROOT_XML_TAG = "multi-scm-log";
 	public static final String SUB_LOG_TAG = "sub-log";
+    public static final int LOG_VERSION = 2;
 	
 	private final Map<String, ChangeLogParser> scmLogParsers;	
 	private final Map<String, String> scmDisplayNames;	
@@ -51,6 +58,7 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 		private OutputStreamWriter outputStream;
 		private boolean newStream;
 		private String scmClass;
+		private int scmParseVersion = 1;
 		
 		public LogSplitter(AbstractBuild build, String tempFilePath) {
 			changeLogs = new MultiSCMChangeLogSet(build);
@@ -70,7 +78,8 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 				            length -= 1;
 				        }
 				    }
-					outputStream.write(data, startIndex, length);
+
+				    outputStream.write(data, startIndex, length);
 					newStream = false;
 				}
 			} catch (IOException e) {
@@ -84,13 +93,21 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 			if(qName.compareTo(SUB_LOG_TAG) == 0) {
 				FileOutputStream fos;
 				try {
-					scmClass = attrs.getValue("scm");
+				    scmClass = attrs.getValue("scm");
 					newStream = true;
 					fos = new FileOutputStream(tempFile);
 				} catch (FileNotFoundException e) {
 					throw new SAXException("could not create temp changelog file", e);
 				}
 				outputStream = new OutputStreamWriter(fos);
+			} else if (qName.compareTo(ROOT_XML_TAG) == 0) {
+			    String parseVersion = attrs.getValue("version");
+
+                if (parseVersion != null) {
+                    scmParseVersion = Integer.parseInt(parseVersion);
+                } else {
+                    scmParseVersion = 1;
+                }
 			}
 		}
 
@@ -102,6 +119,11 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 				try {
 					outputStream.close();
 					outputStream = null;
+
+				if (scmParseVersion >= LOG_VERSION) {
+					decodeNestedCdata(tempFile);
+				}
+
 					ChangeLogParser parser = scmLogParsers.get(scmClass);
 					if(parser != null) {
 						ChangeLogSet<? extends ChangeLogSet.Entry> cls = parser.parse(build, tempFile);
@@ -115,7 +137,37 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 			}
 		}
 
-		public ChangeLogSet<? extends Entry> getChangeLogSets() {
+		/**
+		 * Attempts to decode the "]" and "&" characters from the temp file.
+		 *
+		 * @param tempFile
+		 * @throws IOException
+		 * @see {@link MultiSCM#checkout(AbstractBuild, hudson.Launcher, hudson.FilePath, hudson.model.BuildListener, File)}
+		 */
+        private void decodeNestedCdata(File tempFile) throws IOException {
+            File temp2 = File.createTempFile("tempDecode", ".tmp");
+            BufferedReader reader = new BufferedReader(new FileReader(tempFile));
+            PrintWriter writer = new PrintWriter(new FileWriter(temp2));
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                writer.println(line.replace("&93;&93;&gt;", "]]>").replace("&amp;", "&"));
+            }
+
+            reader.close();
+            writer.close();
+
+            File temp3 = File.createTempFile("jhh", ".tmp");//XXX
+            Files.copy(tempFile, temp3);
+
+            tempFile.delete();
+
+            if (!temp2.renameTo(tempFile)) {
+                Files.move(temp2, tempFile);
+            }
+        }
+
+        public ChangeLogSet<? extends Entry> getChangeLogSets() {
 			return changeLogs;
 		}		
 	}

--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
@@ -33,7 +33,7 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 
 	public static final String ROOT_XML_TAG = "multi-scm-log";
 	public static final String SUB_LOG_TAG = "sub-log";
-    public static final int LOG_VERSION = 2;
+	public static final int LOG_VERSION = 2;
 	
 	private final Map<String, ChangeLogParser> scmLogParsers;	
 	private final Map<String, String> scmDisplayNames;	
@@ -93,7 +93,7 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 			if(qName.compareTo(SUB_LOG_TAG) == 0) {
 				FileOutputStream fos;
 				try {
-				    scmClass = attrs.getValue("scm");
+					scmClass = attrs.getValue("scm");
 					newStream = true;
 					fos = new FileOutputStream(tempFile);
 				} catch (FileNotFoundException e) {
@@ -101,13 +101,11 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 				}
 				outputStream = new OutputStreamWriter(fos);
 			} else if (qName.compareTo(ROOT_XML_TAG) == 0) {
-			    String parseVersion = attrs.getValue("version");
+				String parseVersion = attrs.getValue("version");
 
-                if (parseVersion != null) {
-                    scmParseVersion = Integer.parseInt(parseVersion);
-                } else {
-                    scmParseVersion = 1;
-                }
+				if (parseVersion != null) {
+					scmParseVersion = Integer.parseInt(parseVersion);
+				}
 			}
 		}
 
@@ -120,9 +118,9 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 					outputStream.close();
 					outputStream = null;
 
-				if (scmParseVersion >= LOG_VERSION) {
-					decodeNestedCdata(tempFile);
-				}
+					if (scmParseVersion >= LOG_VERSION) {
+						decodeNestedCdata(tempFile);
+					}
 
 					ChangeLogParser parser = scmLogParsers.get(scmClass);
 					if(parser != null) {
@@ -144,24 +142,24 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 		 * @throws IOException
 		 * @see {@link MultiSCM#checkout(AbstractBuild, hudson.Launcher, hudson.FilePath, hudson.model.BuildListener, File)}
 		 */
-        private void decodeNestedCdata(File tempFile) throws IOException {
-            File temp2 = File.createTempFile("tempDecode", ".tmp");
-            BufferedReader reader = new BufferedReader(new FileReader(tempFile));
-            PrintWriter writer = new PrintWriter(new FileWriter(temp2));
-            String line;
+		private void decodeNestedCdata(File tempFile) throws IOException {
+			File temp2 = File.createTempFile("tempDecode", ".tmp");
+			BufferedReader reader = new BufferedReader(new FileReader(tempFile));
+			PrintWriter writer = new PrintWriter(new FileWriter(temp2));
+			String line;
 
-            while ((line = reader.readLine()) != null) {
-                writer.println(line.replace("&93;&93;&gt;", "]]>").replace("&amp;", "&"));
-            }
+			while ((line = reader.readLine()) != null) {
+				writer.println(line.replace("&93;&93;&gt;", "]]>").replace("&amp;", "&"));
+			}
 
-            reader.close();
-            writer.close();
-            tempFile.delete();
+			reader.close();
+			writer.close();
+			tempFile.delete();
 
-            if (!temp2.renameTo(tempFile)) {
-                Files.move(temp2, tempFile);
-            }
-        }
+			if (!temp2.renameTo(tempFile)) {
+				Files.move(temp2, tempFile);
+			}
+		}
 
         public ChangeLogSet<? extends Entry> getChangeLogSets() {
 			return changeLogs;


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-14537

The plugin makes use of string concatenation in order to build the XML file (using `<%s scm=\"%s\">\n<![CDATA[%s]]>\n</%s>\n` as a pattern to fill in plain Strings).  But then the plugin makes use of a SAX parser to parse the results.  Because the original XML file was not created using a proper XML generator, the result cannot be assumed to be properly formatted XML.

The simple test is to have a commit that simply includes the string "`]]>`".  The result will be that there are no new commits listed in the change log, and a *huge* stack trace dumped to the Jenkins log file.

In order to maintain backward compatibility (e.g., so it doesn't inadvertently decode entities from previous version of the plugin), it will only attempt the conversion if the `<multiple-scm-log>` node contains the `version="2"` attribute.