### PR TITLE
Some SCM's does not always produce change logs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCM.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCM.java
@@ -123,15 +123,16 @@ public class MultiSCM extends SCM implements Saveable {
 					revisionState.add(scm, workspace, build, (SCMRevisionState) a);
 				}
 			}
-			
-			String subLogText = FileUtils.readFileToString(subChangeLog);
-			logWriter.write(String.format("<%s scm=\"%s\">\n<![CDATA[%s]]>\n</%s>\n",
-					MultiSCMChangeLogParser.SUB_LOG_TAG,
-					scm.getType(),
-					subLogText,
-					MultiSCMChangeLogParser.SUB_LOG_TAG));
+			if (subChangeLog.exists()) {
+				String subLogText = FileUtils.readFileToString(subChangeLog);
+				logWriter.write(String.format("<%s scm=\"%s\">\n<![CDATA[%s]]>\n</%s>\n",
+						MultiSCMChangeLogParser.SUB_LOG_TAG,
+						scm.getType(),
+						subLogText,
+						MultiSCMChangeLogParser.SUB_LOG_TAG));
 
-			subChangeLog.delete();
+				subChangeLog.delete();
+			}
 		}
 		logWriter.write(String.format("</%s>\n", MultiSCMChangeLogParser.ROOT_XML_TAG));
 		logWriter.close();


### PR DESCRIPTION
Some SCM's does not always produce change logs, for example the CVS with Skip Change log enabled, and a missing changelog made this plugin fail. Fixed by checking if the Changelog exists before reading it.
