### PR TITLE
Do not add a SCMRevisionState of type MultiSCMRevisionState

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCM.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCM.java
@@ -115,11 +115,15 @@ public class MultiSCM extends SCM implements Saveable {
 		
 		for(SCM scm : scms) {			
 			File subChangeLog = changelogFile != null ? new File(changelogFile.getPath() + ".temp") : null;
-			scm.checkout(build, launcher, workspace, listener, subChangeLog, oldBaseline != null ? oldBaseline.get(scm, workspace, build instanceof AbstractBuild ? (AbstractBuild) build : null) : null);
+			SCMRevisionState workspaceRevision = null;
+			if (oldBaseline != null) {
+                            workspaceRevision = oldBaseline.get(scm, workspace, build instanceof AbstractBuild ? (AbstractBuild) build : null);
+			}
+			scm.checkout(build, launcher, workspace, listener, subChangeLog, workspaceRevision);
 			
 			List<Action> actions = build.getActions();
 			for(Action a : actions) {
-				if(!scmActions.contains(a) && a instanceof SCMRevisionState) {
+				if(!scmActions.contains(a) && a instanceof SCMRevisionState && !(a instanceof MultiSCMRevisionState)) {
 					scmActions.add(a);
 					revisionState.add(scm, workspace, build, (SCMRevisionState) a);
 				}


### PR DESCRIPTION
to the MultiSCMRevisionState variable associated with the overal job.

When a MultiSCM.checkout() is done, the list of SCMs is iterated
over.  For each SCM in the list, we obtain the SCMRevisionState
for that SCM and pass it down to the checkout() method for each SCM.
For a Subversion checkout, the Subversion plugin
downcasts the revision revision state to SVNRevisionState.

Without this fix, a revision state of type MultiSCMRevisionState
was being passed down into the Subversion plugin.  This was
causing a ClassCastException to be thrown.

[JENKINS-26303]