### PR TITLE
Changing to key change parsers off of SCM.getKey() instead of getType().

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCM.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCM.java
@@ -129,7 +129,7 @@ public class MultiSCM extends SCM implements Saveable {
 				//Dont forget to escape the XML in case there is any CDATA sections
 				logWriter.write(String.format("<%s scm=\"%s\">\n<![CDATA[%s]]>\n</%s>\n",
 						MultiSCMChangeLogParser.SUB_LOG_TAG,
-						scm.getType(),
+						scm.getKey(),
 						StringEscapeUtils.escapeXml(subLogText),
 						MultiSCMChangeLogParser.SUB_LOG_TAG));
 

--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
@@ -36,7 +36,7 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 		scmLogParsers = new HashMap<String, ChangeLogParser>();
 		scmDisplayNames = new HashMap<String, String>();
 		for(SCM scm : scms) {
-            String key = scm.getType();
+            String key = scm.getKey();
 			if(!scmLogParsers.containsKey(key)) {
 				scmLogParsers.put(key, scm.createChangeLogParser());
 				scmDisplayNames.put(key, scm.getDescriptor().getDisplayName());


### PR DESCRIPTION
This change is required since different ChangeLogParsers are needed when
multiple git SCMs are used, since each goes to a different repository.

Tested only with git, but should not break other SCMs because of how
getKey() is defined in the Jenkins API.