### PR TITLE
Do not prevent run status page from loading if parsing fails.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
@@ -100,7 +100,9 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
 						changeLogs.add(scmClass, scmDisplayNames.get(scmClass), cls);
 						
 					}
-				} catch (FileNotFoundException e) {
+				} catch (RuntimeException e) {
+                    throw new SAXException("could not parse changelog file", e);
+                } catch (FileNotFoundException e) {
 					throw new SAXException("could not create temp changelog file", e);
 				} catch (IOException e) {
 					throw new SAXException("could not close temp changelog file", e);


### PR DESCRIPTION
If parsing the changelog file fails the UI will display the error:

```
javax.servlet.ServletException: org.apache.commons.jelly.JellyTagException: jar:file:/var/cache/jenkins/war/WEB-INF/lib/jenkins-core-1.580.1.jar!/hudson/model/AbstractBuild/index.jelly:67:61: <st:include> No page found 'digest.jelly' for class hudson.model.FreeStyleBuild
```

This PR will still allow the page to continue to load and display the "No changes were found" message in the changelog. The original error message _will still be_ in the console output in order to diagnose the parsing issue.

@reviewbybees