### PR TITLE
Add support for Custom SCM Names & ChangeSet Repository Browsing

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java
@@ -38,7 +38,11 @@ public class MultiSCMChangeLogParser extends ChangeLogParser {
             String key = scm.getKey();
             if(!scmLogParsers.containsKey(key)) {
                 scmLogParsers.put(key, scm.createChangeLogParser());
-                scmDisplayNames.put(key, scm.getDescriptor().getDisplayName());
+                String displayName = scm.getDescriptor().getDisplayName();
+                if (key != displayName) {
+                    displayName = String.format("%s (%s)", displayName, key);
+                }
+                scmDisplayNames.put(key, displayName);
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogSet.java
+++ b/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogSet.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import hudson.model.AbstractBuild;
+import hudson.scm.RepositoryBrowser;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
 import java.util.HashSet;
@@ -29,6 +30,13 @@ public class MultiSCMChangeLogSet extends ChangeLogSet<Entry> {
 
         public ChangeLogSetWrapper(AbstractBuild build, String friendlyName, Class handler) {
             super(build);
+            this.logs = new ArrayList<Entry>();
+            this.clazz = handler;
+            this.friendlyName = friendlyName;
+        }
+
+        public ChangeLogSetWrapper(AbstractBuild build, RepositoryBrowser<?> browser, String friendlyName, Class handler) {
+            super(build, browser);
             this.logs = new ArrayList<Entry>();
             this.clazz = handler;
             this.friendlyName = friendlyName;
@@ -109,7 +117,7 @@ public class MultiSCMChangeLogSet extends ChangeLogSet<Entry> {
         if(!cls.isEmptySet()) {
             ChangeLogSetWrapper wrapper = changes.get(scmClass);
             if(wrapper == null) {
-                wrapper = new ChangeLogSetWrapper(build, scmFriendlyName, cls.getClass());
+                wrapper = new ChangeLogSetWrapper(build, cls.getBrowser(), scmFriendlyName, cls.getClass());
                 changes.put(scmClass, wrapper);
             }
             wrapper.addChanges(cls);

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogSet/digest.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogSet/digest.jelly
@@ -9,6 +9,7 @@
     <j:otherwise>
       Changes
       <j:forEach var="wrapper" items="${it.ChangeLogSetWrappers}">
+        <j:set var="browser" value="${wrapper.browser == null ? it.build.parent.scm.effectiveBrowser : wrapper.browser}"/>
       	<p>
   		<st:out value="${wrapper.name}"/>
   		</p>


### PR DESCRIPTION
I found that a repository sets a custom SCM name in its configuration, that names is never mentioned in the displays generated by the Multi-SCM plugin.  This change alters the Display Name generator function for each SCM to include the Custom SCM name if one is set in the Display Name generated.

In addition, the ChangeLogSetWrapper has been extended to remember if a repository browser has been set on an SCM and to use it when rendering the change set for that SCM.