### PR TITLE
Fix multi-scm configuration templates confusing sub-SCM config templates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@
         <artifactId>maven-hpi-plugin</artifactId>
         <version>${maven-hpi-plugin.version}</version>
         <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-taglib-interface</goal>
+            </goals>
+          </execution>
+        </executions>
      </plugin>
      <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/MultiSCM/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/MultiSCM/config.jelly
@@ -1,7 +1,12 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="org/jenkinsci/plugins/multiplescms/forms">
+	<!-- promote multiscm value to new template names -->
+	<j:set var="multiscmd" value="${scmd}" />
+	<j:set var="multiscm" value="${scm}" />
+	<j:set var="multiscm_instance" value="${instance}" />
+
 	<f:block>
-	  <f:hetero-list name="scmList" hasHeader="true"
+	  <p:hetero-list-scm name="scmList" hasHeader="true"
 	                 descriptors="${descriptor.getApplicableSCMs(it)}"
 	                 items="${instance.configuredSCMs}"
 	                 addCaption="Add SCM"

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm.jelly
@@ -1,0 +1,145 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+  <st:documentation>
+    Outer most tag for creating a heterogeneous list, where the user can choose arbitrary number of
+    arbitrary items from the given list of descriptors, and configure them independently.
+
+    The submission can be data-bound into List&lt;T> where T is the common base type for the describable instances.
+
+    For databinding use, please use &lt;f:repeatableHeteroProperty />
+
+    <st:attribute name="name" use="required">
+      form name that receives an array for all the items in the heterogeneous list.
+    </st:attribute>
+    <st:attribute name="items" use="required" type="java.util.Collection">
+      existing items to be displayed. Something iterable, such as array or collection.
+    </st:attribute>
+    <st:attribute name="descriptors" use="required">
+      all types that the user can add.
+    </st:attribute>
+    <st:attribute name="addCaption">
+      caption of the 'add' button.
+    </st:attribute>
+    <st:attribute name="deleteCaption">
+      caption of the 'delete' button.
+    </st:attribute>
+    <st:attribute name="targetType">
+      the type for which descriptors will be configured. Defaults to ${it.class} (optional)
+    </st:attribute>
+    <st:attribute name="hasHeader">
+      For each item, add a caption from descriptor.getDisplayName().
+      This also activates drag&amp;drop (where the header is a grip), and help text support.
+    </st:attribute>
+    <st:attribute name="oneEach">
+      If true, only allow up to one instance per descriptor.
+    </st:attribute>
+    <st:attribute name="menuAlign">
+      Menu alignment against the button. Defaults to tl-bl
+    </st:attribute>
+    <st:attribute name="honorOrder">
+      If true, insert new addition by default to their 'desired' location, which
+      is the order induced by the descriptors.
+    </st:attribute>
+    <st:attribute name="capture">
+      Config fragments from descriptors are rendered lazily by default, which means
+      variables seen in the caller aren't visible to them. This attribute allows you
+      to nominate additional variables and their values to be captured for descriptors.
+    </st:attribute>
+  </st:documentation>
+  <d:taglib uri="local">
+    <d:tag name="body">
+      <table style="width:100%">
+        <j:set var="help" value="${descriptor.helpFile}" />
+        <j:if test="${hasHeader}">
+          <tr>
+            <td colspan="3">
+              <div class="dd-handle">
+                <b>${descriptor.displayName}</b>
+              </div>
+            </td>
+            <f:helpLink url="${help}"/>
+          </tr>
+          <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->
+          <j:if test="${help!=null}">
+            <f:helpArea />
+          </j:if>
+        </j:if>
+
+        <d:invokeBody/>
+
+        <f:class-entry descriptor="${descriptor}" />
+        <f:block>
+          <div align="right">
+            <f:repeatableDeleteButton value="${attrs.deleteCaption}" />
+          </div>
+        </f:block>
+      </table>
+    </d:tag>
+  </d:taglib>
+
+  <st:adjunct includes="lib.form.hetero-list.hetero-list"/>
+
+  <j:set var="targetType" value="${attrs.targetType?:it.class}"/>
+  <div class="hetero-list-container ${hasHeader?'with-drag-drop':''} ${attrs.oneEach?'one-each':''} ${attrs.honorOrder?'honor-order':''}">
+    <!-- display existing items -->
+    <j:forEach var="i" items="${attrs.items}">
+      <j:set var="descriptor" value="${i.descriptor}" />
+      <j:set var="instance" value="${i}" />
+      <j:set var="scm" value="${i}" />
+      <j:set var="scmd" value="${i.descriptor}" />
+      <div name="${attrs.name}" class="repeated-chunk" descriptorId="${descriptor.id}">
+        <local:body deleteCaption="${attrs.deleteCaption}">
+          <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true" />
+        </local:body>
+      </div>
+    </j:forEach>
+
+    <div class="repeatable-insertion-point" />
+
+    <div class="prototypes to-be-removed">
+      <!-- render one prototype for each type -->
+      <j:set var="instance" value="${null}" />
+      <j:set var="descriptors" value="${h.filterDescriptors(it,attrs.descriptors)}" />
+      <j:forEach var="descriptor" items="${descriptors}" varStatus="loop">
+        <div name="${attrs.name}" title="${descriptor.displayName}" tooltip="${descriptor.tooltip}" descriptorId="${descriptor.id}">
+          <j:set var="capture" value="${attrs.capture?:''}" />
+          <local:body deleteCaption="${attrs.deleteCaption}">
+            <l:renderOnDemand tag="tr" clazz="config-page" capture="descriptor,it,instance,${capture}">
+              <l:ajax>
+                <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true" />
+              </l:ajax>
+            </l:renderOnDemand>
+          </local:body>
+        </div>
+      </j:forEach>
+    </div>
+
+    <div>
+      <input type="button" value="${attrs.addCaption?:'%Add'}" class="hetero-list-add" menualign="${attrs.menuAlign}" suffix="${attrs.name}"/>
+    </div>
+  </div>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_da.properties
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_da.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc. Kohsuke Kawaguchi. Knud Poulsen.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Add=Tilf\u00f8j

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_de.properties
@@ -1,0 +1,1 @@
+Add=Hinzufügen

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_es.properties
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_es.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Add=Añadir

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_fr.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Add=Ajouter

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_ja.properties
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_ja.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Seiji Sogabe
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Add=\u8FFD\u52A0

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_pt_BR.properties
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_pt_BR.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc., Cleiber Silva
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Add=Adicionar

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_ru.properties
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_ru.properties
@@ -1,0 +1,3 @@
+# This file is under the MIT License by authors
+
+Add=\u0414\u043E\u0431\u0430\u0432\u0438\u0442\u044C

--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_zh_TW.properties
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/forms/hetero-list-scm_zh_TW.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Add=\u65B0\u589E


### PR DESCRIPTION
When the Git Plugin is called via the Multi-SCM Plugin Configuration templates, the template variables are in a mixed state using Multi-SCM configuration values and Git Plugin Configuration values. The template variables affected are:
  * scmd
  * scm
  * instance

The extended copy of the hetero-list jelly macro from the jenkins core module should fix the issue of the template variables being in a mixed state (Some MultiSCM/Some sub-SCM).  The multi SCM values are promoted to new variables names (*multiscmd*, *multiscm*, *multiscm_instance*) and the **scmd**, **scm**, **instance** variables are treated as template loop variables.

A brief description of how the GIT config template renders under the Multi-SCM plugin follows.

The SCM Configuration templates start in:
  * jenkins/core/src/main/resources/lib/hudson/project/config-scm.jelly

This template sets the scmd, scm, instance template variables for the Multi-SCM plugin and renders its config template.

The Multi-SCM plugin config template calls the jenkins hetero-list macro to configure multiple SCMs.
  * multiple-scms-plugin/src/main/resources/org/jenkinsci/plugins/multiplescms/MultiSCM

The hetero-list macro partially overrides the template variables by setting **instance** to "real" SCM being selected by the hetero-list, in the case of the Git Plugin, the Git Plugin DescriptorImpl. The **scmd** and **scm** template variables are unchanged.
  * jenkins/core/src/main/resources/lib/form/hetero-list.jelly

At this point we enter the Git Plugin Config template with the template variables set as:
  * **scmd** = org.jenkinsci. plugins.multiplescms.MultiSCM$DescriptorImpl@xxxx
  * **scm** = org.jenkinsci.plugins.multiplescms.MultiSCM@xxxx
  * **instance** = hudson.plugins.git.GitSCM@xxxx

There are further macros used by the Git Plugin and others which rely on the **scmd** and **scm** variables being set to the current SCM being configured.