### PR TITLE
Allow Annotated Change Log messages to appear in multi-scm change log digest.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogSet/digest.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogSet/digest.jelly
@@ -16,7 +16,7 @@
   		<ol>      
   			<j:forEach var="cs" items="${wrapper.logs}">
 	          <li>
-	            ${cs.msgAnnotated}
+	            <j:out value="${cs.msgAnnotated}" />
 	            (<a href="changes#detail${loop.index}">detail</a>
 	            <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>
 	            <j:if test="${cslink!=null}">


### PR DESCRIPTION
Auto-escape was enabled in the change log templates via commit 17d0725815a24ecbdd7cf636b47d30f8f113219d. However, annotated change log messages assume they will not be escaped and sometimes include HTML content. Without disabling the auto-escape for annotated change log messages, the messages appear as plain text.

An example configuration would be the Jira Plugin with any SCM.