### PR TITLE
[INFRA-2243] Switch to new buildPluginWithGradle() step in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,1 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPluginWithGradle(tests: [skip: true])


### PR DESCRIPTION
### [INFRA-2243](https://issues.jenkins-ci.org/browse/INFRA-2243) Split Maven and Gradle steps in Pipeline Library

There should be no difference in behaviour at the moment.
The existing `buildPlugin()` step is deprecated for Gradle-based plugins.
The new step is planned to get new Gradle/Groovy functionality over time.

Skipping tests as the pipeline on ci.jenkins.io otherwise tries to collect
test results which would fail because no tests have been implemented.